### PR TITLE
Fixed typo in python scraping lab test

### DIFF
--- a/python/scraping-lab/test_xom.py
+++ b/python/scraping-lab/test_xom.py
@@ -3,7 +3,7 @@ import yahoo_options_data
 
 computedJson = yahoo_options_data.contractAsJson("xom.dat")
 expectedJson = open("xom.json").read()
-expectedJson_changed = open("xom_changed.json").read()
+expectedJson_changed = open("xom_change.json").read()
 
 if json.loads(computedJson) != json.loads(expectedJson) and json.loads(computedJson) != json.loads(expectedJson_changed):
   print "Test failed!"


### PR DESCRIPTION
This is a quick fix for a filename typo in one of the python scraper labs. The test_xom.py file should refer to the "xom_change.json" file instead of "xom_changed.json".
