### PR TITLE
Reseting InputStream, so that it's reusable.

### DIFF
--- a/JavaExpts/EPI/java/src/main/java/com/epi/KthLargestElementLargeN.java
+++ b/JavaExpts/EPI/java/src/main/java/com/epi/KthLargestElementLargeN.java
@@ -39,9 +39,11 @@ public class KthLargestElementLargeN {
         System.out.println("IOException: " + e.getMessage());
       }
       ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-
+      bais.mark(0);
+    
       for (int i = 0; i < a.length; i++) {
         System.out.println("i = " + i);
+        bais.reset();
         int result = findKthLargestUnknownLength(bais, i+1);
         System.out.println(result);
       }


### PR DESCRIPTION
Once `bais` has been used for the first time, it can't be in subsequent tests. The consequence is that only the first iteration actually gets some data to "play" with, while all others get nothing. By marking and reseting the input stream, all iterations get something.